### PR TITLE
Set up ClickUp with Github for code change updates

### DIFF
--- a/prlint.json
+++ b/prlint.json
@@ -1,0 +1,8 @@
+{
+  "title": [
+    {
+      "pattern": "\\[CU-[0-9]{3,8}\\]\\s[A-Z].*",
+      "message": "A ClickUp story is required in the pull request title. Ex: [CU-123] Add X button to Y page"
+    }
+  ]
+}


### PR DESCRIPTION
### Description

Added a config file for the PRLint Github App, which enforces that every PR has a ClickUp task ID in the PR title. This rule will apply to all repos by default.

### Other changes

N/A

### Tested

TODO

### Related issues

- https://app.clickup.com/t/318xye3

### Backwards compatibility

All new PRs will require a ClickUp task ID in the title.
