### PR TITLE
Remove ClickUp title enforcement config from .github repo

### DIFF
--- a/prlint.json
+++ b/prlint.json
@@ -1,8 +1,0 @@
-{
-  "title": [
-    {
-      "pattern": "\\[CU-[0-9]{3,8}\\]\\s[A-Z].*",
-      "message": "A ClickUp story is required in the pull request title. Ex: [CU-123] Add X button to Y page"
-    }
-  ]
-}


### PR DESCRIPTION
### Description

Remove PRLint GitHub app config from the default repo. The config needs to be added to each individual repo for PR title enforcement.

### Other changes

N/A

### Tested

N/A

### Related issues

- https://app.clickup.com/t/36ew9yq

### Backwards compatibility

N/A
